### PR TITLE
Use EntityFrameworkCore.Exceptions to handle database errors

### DIFF
--- a/src/LangProwess.Server/Data/AppDbContext.cs
+++ b/src/LangProwess.Server/Data/AppDbContext.cs
@@ -1,3 +1,4 @@
+using EntityFramework.Exceptions.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace LangProwess.Server.Data;
@@ -11,7 +12,9 @@ class AppDbContext : DbContext
 	private string DbPath { get; }
 
 	protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-		=> optionsBuilder.UseSqlite($"Data Source={DbPath}");
+		=> optionsBuilder
+			.UseSqlite($"Data Source={DbPath}")
+			.UseExceptionProcessor();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{

--- a/src/LangProwess.Server/LangProwess.Server.csproj
+++ b/src/LangProwess.Server/LangProwess.Server.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.Exceptions.Sqlite" Version="6.0.3" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.2" />


### PR DESCRIPTION
Use [EntityFrameworkCore.Exceptions](https://github.com/Giorgi/EntityFramework.Exceptions) to convert `DbException` to more specific types as `UniqueConstraintException`, `CannotInsertNullException`, etc.

More detailed logs and easier error handling