### PR TITLE
Remove `end_of_line = lf` from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -230,7 +230,6 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
-end_of_line = lf
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion


### PR DESCRIPTION
`end_of_line = lf` shouldn't be enforced in working directories as git already normalizes EOLs in the index.